### PR TITLE
Port to giflib 5.0.5

### DIFF
--- a/rwgif.c
+++ b/rwgif.c
@@ -54,7 +54,8 @@ open_gif_file (const char *filename, int *width, int *height)
     
     assert(data != 0);
     
-    data->file = DGifOpenFileName(filename);
+    int error;
+    data->file = DGifOpenFileName(filename, &error);
     
     assert(data->file !=0);
         


### PR DESCRIPTION
I'm not sure when this API change was introduced in giflib, but with this patch compilation works using giflib 5.0.5 (and fails without it).
We might want to do further error handling depending on the value of error if NULL was returned.
